### PR TITLE
Datatype links and Hugo inter-page links

### DIFF
--- a/src/common/datatypes.xsl
+++ b/src/common/datatypes.xsl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="3.0">
+    <!--
+         Normalize deprecated datatype names
+         ex. m:datatype-normalize('dateTime-with-timezone') => date-time-with-timezone
+         Note: unknown and valid datatypes will be passed along as-is
+    -->
+    <xsl:function
+        name="m:datatype-normalize" as="xs:string">
+        <xsl:param name="raw-datatype" as="xs:string" />
+        <xsl:variable name="deprecation-map">
+            <!-- these old names are permitted for now, while only deprecated -->
+            <!--metaschema/schema/xml/metaschema.xsd
+                 line 1052 inside  /*/xs:simpleType[@name='SimpleDatatypesType']> -->
+            <entry key="base64Binary">base64</entry>
+            <entry key="dateTime">date-time</entry>
+            <entry key="dateTime-with-timezone">date-time-with-timezone</entry>
+            <entry key="email">email-address</entry>
+            <entry key="nonNegativeInteger">non-negative-integer</entry>
+            <entry key="positiveInteger">positive-integer</entry>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="$deprecation-map/entry[@key=$raw-datatype]">
+                <xsl:value-of select="$deprecation-map/entry[@key=$raw-datatype]"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$raw-datatype"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    
+    <!-- used in documentation generation pipelines -->
+    <xsl:variable name="metaschema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:variable>
+    
+    <!--
+         Create an href link to the metaschema documentation for a given datatype
+         Warning this function makes no attempt to validate datatype names, only fixing explicitly deprecated names.
+    -->
+    <xsl:function name="m:datatype-create-link" as="element()">
+        <xsl:param name="raw-datatype" as="xs:string" />
+        <xsl:variable name="datatype" as="xs:string" select="m:datatype-normalize($raw-datatype)" />
+        <a href="{$metaschema-reference-url}/#{$datatype}">
+            <xsl:value-of select="$datatype"/>
+        </a>
+    </xsl:function>
+</xsl:stylesheet>

--- a/src/common/datatypes.xsl
+++ b/src/common/datatypes.xsl
@@ -42,8 +42,14 @@
     <xsl:function name="m:datatype-create-link" as="element()">
         <xsl:param name="raw-datatype" as="xs:string" />
         <xsl:variable name="datatype" as="xs:string" select="m:datatype-normalize($raw-datatype)" />
-        <a href="{$metaschema-reference-url}/#{$datatype}">
+        
+        <xsl:element name="a">
+            <xsl:attribute name="href">
+                <xsl:value-of select="$metaschema-reference-url"/>
+                <xsl:text>/#</xsl:text>
+                <xsl:value-of select="$datatype"/>
+            </xsl:attribute>
             <xsl:value-of select="$datatype"/>
-        </a>
+        </xsl:element>
     </xsl:function>
 </xsl:stylesheet>

--- a/src/common/datatypes.xsl
+++ b/src/common/datatypes.xsl
@@ -33,7 +33,7 @@
     </xsl:function>
     
     <!-- used in documentation generation pipelines -->
-    <xsl:variable name="metaschema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:variable>
+    <xsl:param name="metaschema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:param>
     
     <!--
          Create an href link to the metaschema documentation for a given datatype

--- a/src/document/common/common-definitions.xsl
+++ b/src/document/common/common-definitions.xsl
@@ -10,8 +10,6 @@
     <xsl:key name="assembly-definition-by-name" match="/METASCHEMA/define-assembly" use="@_key-name"/>
     <xsl:key name="field-definition-by-name" match="/METASCHEMA/define-field"       use="@_key-name"/>
     <xsl:key name="flag-definition-by-name" match="/METASCHEMA/define-flag"         use="@_key-name"/>
-    
-    <xsl:variable name="meta-schema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:variable>
 
     <xsl:variable name="indenting" as="element()"
         xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
@@ -238,10 +236,11 @@
    
     <!-- override this -->
     <xsl:template mode="metaschema-type" match="*" expand-text="true">{ local-name() }</xsl:template>
-        
+    
+    <xsl:import href="../../common/datatypes.xsl"/>
     <!-- expect overriding XSLT to provide metaschema type with appropriate link  -->
     <xsl:template mode="metaschema-type" match="*[exists(@as-type)]" expand-text="true">
-        <a href="{$meta-schema-reference-url}/#{(lower-case(@as-type))}">{@as-type}</a>
+        <xsl:sequence select="m:datatype-create-link(@as-type)"/>
     </xsl:template>
     
     <xsl:template priority="5" match="choice">

--- a/src/document/json/json-docs-hugo-uswds.xsl
+++ b/src/document/json/json-docs-hugo-uswds.xsl
@@ -19,7 +19,6 @@
 
    <xsl:variable name="metaschema-code" select="/*/short-name || '-json'"/>
 
-   <xsl:variable name="meta-schema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:variable>
    <xsl:strip-space elements="*"/>
 
    <xsl:preserve-space elements="p li pre i b em strong a code q"/>
@@ -1181,19 +1180,17 @@
       <xsl:apply-templates select="key('assembly-definitions', @ref)" mode="#current"/>
    </xsl:template>
 
+   <xsl:import href="../../common/datatypes.xsl"/>
+
    <xsl:template mode="metaschema-type" match="define-field[empty(flag | define-flag)]">
       <xsl:variable name="given-type" select="(@as-type, 'string')[1]"/>
-      <a href="{$meta-schema-reference-url}/#{(lower-case($given-type))}">
-         <xsl:apply-templates mode="#current" select="$given-type"/>
-      </a>
+      <xsl:sequence select="m:datatype-create-link($given-type)"/>
    </xsl:template>
 
    <xsl:template mode="metaschema-type" match="flag | define-flag">
       <xsl:variable name="given-type"
          select="(@as-type, key('flag-definitions', @ref, $home)/@as-type, 'string')[1]"/>
-      <a href="{$meta-schema-reference-url}/#{(lower-case($given-type))}">
-         <xsl:apply-templates mode="#current" select="$given-type"/>
-      </a>
+      <xsl:sequence select="m:datatype-create-link(@given-type)"/>
    </xsl:template>
 
    <xsl:variable name="numeric-types"

--- a/src/document/json/object-map-html.xsl
+++ b/src/document/json/object-map-html.xsl
@@ -18,8 +18,6 @@
    </xsl:variable>
    <xsl:variable name="reference-link" select="$path-to-common || $reference-page"/> 
    
-   <xsl:variable name="meta-schema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:variable>
-   
    <xsl:template match="/" mode="make-page">
       <html lang="en">
          <head>
@@ -277,8 +275,11 @@ details:not([open]) .show-closed { display: inline }
       </div>
    </xsl:template>
    
+   <xsl:import href="../../common/datatypes.xsl"/>
    <xsl:template priority="2" mode="inline-link-to" match="m:string" expand-text="true">
-      <span class="OM-datatype"><a href="{$meta-schema-reference-url}/#{lower-case(@as-type)}">{ @as-type }</a></span>
+      <span class="OM-datatype">
+         <xsl:sequence select="m:datatype-create-link(@as-type)"/>
+      </span>
    </xsl:template>
    
    <xsl:template mode="contents" match="m:array | m:object | m:singleton-or-array | m:group-by-key">

--- a/src/document/json/object-reference-html.xsl
+++ b/src/document/json/object-reference-html.xsl
@@ -12,9 +12,6 @@
    <xsl:param name="json-map-page"> json/outline</xsl:param>
    <xsl:param name="json-definitions-page">json/definitions</xsl:param>
 
-   <xsl:variable name="datatype-page" as="xs:string">/models/datatypes</xsl:variable>
-   <xsl:variable name="meta-schema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:variable>
-
    <xsl:template match="metadata/namespace"/>
 
    <xsl:template name="remarks-group">
@@ -182,8 +179,9 @@
       </xsl:if>
    </xsl:template>
 
+   <xsl:import href="../../common/datatypes.xsl"/>
    <xsl:template mode="metaschema-type" match="*[exists(@as-type)]" expand-text="true">
-      <a href="{$meta-schema-reference-url}/#{(lower-case(@as-type))}">{ @as-type }</a>
+      <xsl:sequence select="m:datatype-create-link(@as-type)"/>
    </xsl:template>
 
    <xsl:template match="*" mode="report-context" expand-text="true">

--- a/src/document/write-hugo-metaschema-docs.xpl
+++ b/src/document/write-hugo-metaschema-docs.xpl
@@ -17,9 +17,11 @@
 
   <p:input port="parameters" kind="parameter" />
 
-  <!-- expect an absolute URI -->
-
-  <p:option name="output-path" required="true" />
+  <p:option name="output-path" required="true">
+    <p:documentation>
+      The output directory to write to. This should be an absolute URI.
+    </p:documentation>
+  </p:option>
 
   <p:option name="json-outline-filename" select="'json-outline.html'" />
   <p:option name="json-reference-filename" select="'json-reference.html'" />
@@ -30,11 +32,25 @@
   <p:option name="xml-index-filename" select="'xml-index.html'" />
   <p:option name="xml-definitions-filename" select="'xml-definitions.html'" />
 
+  <p:option name="page-base-path" select="''">
+    <p:documentation>
+      The base path that will be prepended to all relative links (e.g. '' or 'model-name/').
+    </p:documentation>
+  </p:option>
+  
+  <p:option name="json-outline-page" select="concat($page-base-path, replace($json-outline-filename, '.html', '/'))" />
+  <p:option name="json-reference-page" select="concat($page-base-path, replace($json-reference-filename, '.html', '/'))" />
+  <p:option name="json-index-page" select="concat($page-base-path, replace($json-index-filename, '.html', '/'))" />
+  <p:option name="json-definitions-page" select="concat($page-base-path, replace($json-definitions-filename, '.html', '/'))" />
+  <p:option name="xml-outline-page" select="concat($page-base-path, replace($xml-outline-filename, '.html', '/'))" />
+  <p:option name="xml-reference-page" select="concat($page-base-path, replace($xml-reference-filename, '.html', '/'))" />
+  <p:option name="xml-index-page" select="concat($page-base-path, replace($xml-index-filename, '.html', '/'))" />
+  <p:option name="xml-definitions-page" select="concat($page-base-path, replace($xml-definitions-filename, '.html', '/'))" />
+
   <!-- &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& -->
   <!-- Import (subpipeline) -->
 
   <p:import href="../compose/metaschema-compose.xpl" />
-
 
   <p:variable name="xml-outline-uri" select="resolve-uri($xml-outline-filename,     $output-path)" />
   <p:variable name="xml-reference-uri" select="resolve-uri($xml-reference-filename,   $output-path)" />
@@ -93,8 +109,8 @@
     <p:input port="stylesheet">
       <p:document href="xml/element-map-html.xsl" />
     </p:input>
-    <p:with-param name="outline-page" select="$xml-outline-filename" />
-    <p:with-param name="reference-page" select="$xml-reference-filename" />
+    <p:with-param name="outline-page" select="$xml-outline-page" />
+    <p:with-param name="reference-page" select="$xml-reference-page" />
   </p:xslt>
 
   <!-- Done with that. -->
@@ -107,10 +123,10 @@
     <p:input port="stylesheet">
       <p:document href="xml/element-reference-html.xsl" />
     </p:input>
-    <p:with-param name="xml-reference-page" select="$xml-reference-filename" />
-    <p:with-param name="xml-definitions-page" select="$xml-definitions-filename" />
-    <p:with-param name="json-reference-page" select="$json-reference-filename" />
-    <p:with-param name="xml-map-page" select="$xml-outline-filename" />
+    <p:with-param name="xml-reference-page" select="$xml-reference-page" />
+    <p:with-param name="xml-definitions-page" select="$xml-definitions-page" />
+    <p:with-param name="json-reference-page" select="$json-reference-page" />
+    <p:with-param name="xml-map-page" select="$xml-outline-page" />
   </p:xslt>
 
   <p:sink />
@@ -122,9 +138,9 @@
     <p:input port="stylesheet">
       <p:document href="xml/element-index-html.xsl" />
     </p:input>
-    <p:with-param name="index-page" select="$xml-index-filename" />
-    <p:with-param name="reference-page" select="$xml-reference-filename" />
-    <p:with-param name="definitions-page" select="$xml-definitions-filename" />
+    <p:with-param name="index-page" select="$xml-index-page" />
+    <p:with-param name="reference-page" select="$xml-reference-page" />
+    <p:with-param name="definitions-page" select="$xml-definitions-page" />
   </p:xslt>
 
   <p:sink />
@@ -139,9 +155,9 @@
       <!-- XXX fix up / reduce this XSLT (from RC2) -->
       <p:document href="xml/xml-definitions.xsl" />
     </p:input>
-    <p:with-param name="xml-definitions-page" select="$xml-definitions-filename" />
-    <p:with-param name="json-definitions-page" select="$json-definitions-filename" />
-    <p:with-param name="xml-reference-page" select="$xml-reference-filename" />
+    <p:with-param name="xml-definitions-page" select="$xml-definitions-page" />
+    <p:with-param name="json-definitions-page" select="$json-definitions-page" />
+    <p:with-param name="xml-reference-page" select="$xml-reference-page" />
   </p:xslt>
 
   <p:sink />
@@ -164,8 +180,8 @@
     <p:input port="stylesheet">
       <p:document href="json/object-map-html.xsl" />
     </p:input>
-    <p:with-param name="outline-page" select="$json-outline-filename" />
-    <p:with-param name="reference-page" select="$json-reference-filename" />
+    <p:with-param name="outline-page" select="$json-outline-page" />
+    <p:with-param name="reference-page" select="$json-reference-page" />
   </p:xslt>
 
   <!-- Done with that. -->
@@ -185,10 +201,10 @@
     <p:input port="stylesheet">
       <p:document href="json/object-reference-html.xsl" />
     </p:input>
-    <p:with-param name="json-reference-page" select="$json-reference-filename" />
-    <p:with-param name="json-definitions-page" select="$json-definitions-filename" />
-    <p:with-param name="xml-reference-page" select="$xml-reference-filename" />
-    <p:with-param name="json-map-page" select="$json-outline-filename" />
+    <p:with-param name="json-reference-page" select="$json-reference-page" />
+    <p:with-param name="json-definitions-page" select="$json-definitions-page" />
+    <p:with-param name="xml-reference-page" select="$xml-reference-page" />
+    <p:with-param name="json-map-page" select="$json-outline-page" />
   </p:xslt>
 
   <p:sink />
@@ -204,9 +220,9 @@
     <p:input port="stylesheet">
       <p:document href="json/object-index-html.xsl" />
     </p:input>
-    <p:with-param name="index-page" select="$json-index-filename" />
-    <p:with-param name="reference-page" select="$json-reference-filename" />
-    <p:with-param name="definitions-page" select="$json-definitions-filename" />
+    <p:with-param name="index-page" select="$json-index-page" />
+    <p:with-param name="reference-page" select="$json-reference-page" />
+    <p:with-param name="definitions-page" select="$json-definitions-page" />
   </p:xslt>
 
   <p:sink />
@@ -221,9 +237,9 @@
       <!-- XXX fix up / reduce this XSLT (from RC2) -->
       <p:document href="json/json-definitions.xsl" />
     </p:input>
-    <p:with-param name="json-definitions-page" select="$json-definitions-filename" />
-    <p:with-param name="xml-definitions-page" select="$xml-definitions-filename" />
-    <p:with-param name="json-reference-page" select="$json-reference-filename" />
+    <p:with-param name="json-definitions-page" select="$json-definitions-page" />
+    <p:with-param name="xml-definitions-page" select="$xml-definitions-page" />
+    <p:with-param name="json-reference-page" select="$json-reference-page" />
   </p:xslt>
 
   <p:sink />

--- a/src/document/xml/element-map-html.xsl
+++ b/src/document/xml/element-map-html.xsl
@@ -16,10 +16,7 @@
       <xsl:for-each select="tokenize($outline-page,'/')">../</xsl:for-each>
    </xsl:variable>
    <xsl:variable name="reference-link" select="$path-to-common || $reference-page"/>
-   
-   
-   <xsl:variable name="meta-schema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:variable>
-   
+      
 <!--http://localhost:1313/OSCAL/documentation/schema/catalog-layer/catalog/xml-model-map/
 http://localhost:1313/OSCAL/documentation/schema/catalog-layer/catalog/xml-schema/-->
 
@@ -91,9 +88,12 @@ div.OM-map p { margin: 0ex }
       <xsl:value-of select="(@gi,@name)[1]"/>
    </xsl:template> 
    
+   <xsl:import href="../../common/datatypes.xsl"/>
    <xsl:template priority="2" mode="linked-datatype" match="*" expand-text="true">
-      <xsl:variable name="type" select="(lower-case(@as-type),'string')[1]"/>
-      <span class="OM-datatype"><a href="{$meta-schema-reference-url}/#{$type}">{ $type }</a></span>
+      <xsl:variable name="type" select="(@as-type,'string')[1]"/>
+      <span class="OM-datatype">
+         <xsl:sequence select="m:datatype-create-link($type)"/>
+      </span>
    </xsl:template>
    
    <xsl:template match="m:element">

--- a/src/document/xml/element-reference-html.xsl
+++ b/src/document/xml/element-reference-html.xsl
@@ -16,8 +16,7 @@
    <xsl:param name="xml-map-page"> xml/outline</xsl:param>
    <xsl:param name="xml-definitions-page">xml/definitions</xsl:param>
 
-   <xsl:variable name="datatype-page" as="xs:string">/models/datatypes</xsl:variable>
-   <xsl:variable name="meta-schema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:variable>
+   <xsl:import href="../../common/datatypes.xsl"/>
 
    <xsl:template match="metadata/json-base-uri"/>
 
@@ -186,7 +185,7 @@
          <div class="body">
             <p>
                <xsl:text>This use of the </xsl:text>
-               <a href="{$meta-schema-reference-url}/#markup-multiline">markup-multiline</a>
+               <xsl:value-of select="m:datatype-create-link('markup-multiline')"/>
                <xsl:text> type permits unwrapped block-level markup.</xsl:text>
             </p>
          </div>
@@ -226,7 +225,7 @@
    </xsl:template>
 
    <xsl:template mode="metaschema-type" match="*[exists(@as-type)]" expand-text="true">
-      <a href="{$meta-schema-reference-url}/#{(lower-case(@as-type))}">{ @as-type }</a>
+      <xsl:sequence select="m:datatype-create-link(@as-type)"/>
    </xsl:template>
 
    <xsl:import href="../common/common-reference.xsl"/>

--- a/src/document/xml/xml-docs-hugo-uswds.xsl
+++ b/src/document/xml/xml-docs-hugo-uswds.xsl
@@ -30,9 +30,7 @@
    <!--  XXX TO DO XXX -->
    <xsl:param name="content-converter-path" select="'#'"/>
 
-   <xsl:variable name="metaschema-code" select="/*/short-name || '-xml'"/> 
-
-   <xsl:variable name="meta-schema-reference-url" as="xs:string">https://pages.nist.gov/metaschema/specification/datatypes</xsl:variable>
+   <xsl:variable name="metaschema-code" select="/*/short-name || '-xml'"/>
 
    <xsl:strip-space elements="*"/>
 
@@ -1106,21 +1104,18 @@
       <xsl:apply-templates select="key('assembly-definitions', @ref)" mode="#current"/>
    </xsl:template>
 
+   <xsl:import href="../../common/datatypes.xsl"/>
 
    <xsl:template mode="metaschema-type" match="flag | define-flag">
       <xsl:variable name="given-type"
          select="(@as-type, key('flag-definitions', @ref)/@as-type, 'string')[1]"/>
-      <a href="{$meta-schema-reference-url}/#{(lower-case($given-type))}">
-         <xsl:apply-templates mode="#current" select="$given-type"/>
-      </a>
+      <xsl:sequence select="m:datatype-create-link($given-type)"/>
    </xsl:template>
 
    <xsl:template mode="metaschema-type" match="define-field">
       <xsl:variable name="given-type"
          select="(@as-type, key('field-definitions', @ref)/@as-type, 'string')[1]"/>
-      <a href="{$meta-schema-reference-url}/#{(lower-case($given-type))}">
-         <xsl:apply-templates mode="#current" select="$given-type"/>
-      </a>
+      <xsl:sequence select="m:datatype-create-link($given-type)"/>
    </xsl:template>
 
    <xsl:template mode="metaschema-type" match="define-assembly">element</xsl:template>


### PR DESCRIPTION
- [x] Fix metaschema datatype links
    - [x] Tested in smoke tests
    - [x] Tested on OSCAL Reference
- [x] Fix the hugo gen links
    - [x] Tested on OSCAL Reference

NOTE: this PR adds an option to the hugo metaschema docs pipeline, requiring a "base path" that is prepended to inter-page links. The relevant changes to the OSCAL Reference have already been tested.